### PR TITLE
fix random seed issue

### DIFF
--- a/utils/helper.go
+++ b/utils/helper.go
@@ -1,6 +1,13 @@
 package utils
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"fmt"
+	"strconvert"
+	"time"
+	"math/rand"
+	"io/ioutil"
+	"github.com/gofiber/fiber/v2"
+)
 
 func WantsJSON(c *fiber.Ctx) bool {
 	if c.Query("json") == "true" {
@@ -16,4 +23,37 @@ func WantsJSON(c *fiber.Ctx) bool {
 client side certificate for this project */
 func BaseURL(c *fiber.Ctx) string {
 	return c.Protocol() + "s://" + c.Hostname()
+}
+
+
+// Get random seed for hourly/daily 
+
+func SetSeed(t string) {
+	var date = time.Now()
+	var day = strconv.Itoa(date.Day())
+	var month = strconv.Itoa(int(date.Month()))
+	var year = strconv.Itoa(date.Year())
+	var joined string
+	if t == "hour" {
+		var hour = strconv.Itoa(date.Hour())
+		joined = year + month + day + hour
+	} else {
+		joined = year + month + day
+	}
+	seed, err := strconv.Atoi(joined)
+	if err != nil {
+		println(err.Error())
+	}
+	rand.Seed(int64(seed))
+}
+
+
+// Get index for random hour/day
+
+func GetIndex() int {
+	files,_ := ioutil.ReadDir("capys/")
+    var max_rand = len(files)
+	// set index
+	var index = rand.Intn(max_rand) + 1
+	return index
 }

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -51,8 +51,8 @@ func SetSeed(t string) {
 // Get index for random hour/day
 
 func GetIndex() int {
-	files,_ := ioutil.ReadDir("capys/")
-    var max_rand = len(files)
+	files, _ := ioutil.ReadDir("capys/")
+    	var max_rand = len(files)
 	// set index
 	var index = rand.Intn(max_rand) + 1
 	return index

--- a/v1/get_capy_hour.go
+++ b/v1/get_capy_hour.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
+	"strconvert"
+	"math/rand"
 	"os"
 	"time"
 
@@ -14,12 +16,25 @@ import (
 func GetCapyHour(c *fiber.Ctx) error {
 	var wantsJSON = utils.WantsJSON(c)
 
+	// sets seed for this hour
 	var date = time.Now()
 	var hour = date.Hour()
 	var day = date.Day()
+	var month = strconv.Itoa(int(date.Month()))
+	var year = strconv.Itoa(date.Year())
+	var joined = year + month + day + hour
+	seed, err := strconv.Atoi(joined)
+	if err != nil {
+		println(err.Error())
+	}
+	rand.Seed(int64(seed))
 
-	// 12 is 0 bruv
-	var index = (hour + 1) + day
+	// find boundary of largest number rand should generate
+	files,_ := ioutil.ReadDir("capys/")
+    var max_rand = len(files)
+
+	// set index
+	var index = rand.Intn(max_rand) + 1
 	bytes, err := ioutil.ReadFile("capys/capy" + fmt.Sprint(index) + ".jpg")
 
 	c.Set("X-Capybara-Index", fmt.Sprint(index))

--- a/v1/get_capy_hour.go
+++ b/v1/get_capy_hour.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
-	"strconvert"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/looskie/capybara-api/utils"
@@ -17,24 +14,11 @@ func GetCapyHour(c *fiber.Ctx) error {
 	var wantsJSON = utils.WantsJSON(c)
 
 	// sets seed for this hour
-	var date = time.Now()
-	var hour = date.Hour()
-	var day = date.Day()
-	var month = strconv.Itoa(int(date.Month()))
-	var year = strconv.Itoa(date.Year())
-	var joined = year + month + day + hour
-	seed, err := strconv.Atoi(joined)
-	if err != nil {
-		println(err.Error())
-	}
-	rand.Seed(int64(seed))
+	utils.SetSeed("hour")
 
-	// find boundary of largest number rand should generate
-	files,_ := ioutil.ReadDir("capys/")
-    var max_rand = len(files)
+	// get random index
+	var index = utils.GetIndex()
 
-	// set index
-	var index = rand.Intn(max_rand) + 1
 	bytes, err := ioutil.ReadFile("capys/capy" + fmt.Sprint(index) + ".jpg")
 
 	c.Set("X-Capybara-Index", fmt.Sprint(index))

--- a/v1/get_capy_of_the_day.go
+++ b/v1/get_capy_of_the_day.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
+	"strconvert"
+	"math/rand"
 	"os"
 	"time"
 
@@ -13,8 +15,24 @@ import (
 
 func GetCapybaraOfTheDay(c *fiber.Ctx) error {
 	var wantsJSON = utils.WantsJSON(c)
-	var _, month, day = time.Now().Date()
-	var index = int(month) + day
+	// sets seed for this day
+	var date = time.Now()
+	var day = date.Day()
+	var month = strconv.Itoa(int(date.Month()))
+	var year = strconv.Itoa(date.Year())
+	var joined = year + month + day
+	seed, err := strconv.Atoi(joined)
+	if err != nil {
+		println(err.Error())
+	}
+	rand.Seed(int64(seed))
+
+	// find boundary of largest random number
+	files,_ := ioutil.ReadDir("capys/")
+    var max_rand = len(files)
+
+	// generate random number & set index
+	var index = rand.Intn(max_rand) + 1
 
 	bytes, err := ioutil.ReadFile("capys/capy" + fmt.Sprint(index) + ".jpg")
 

--- a/v1/get_capy_of_the_day.go
+++ b/v1/get_capy_of_the_day.go
@@ -15,24 +15,11 @@ import (
 
 func GetCapybaraOfTheDay(c *fiber.Ctx) error {
 	var wantsJSON = utils.WantsJSON(c)
+	
 	// sets seed for this day
-	var date = time.Now()
-	var day = date.Day()
-	var month = strconv.Itoa(int(date.Month()))
-	var year = strconv.Itoa(date.Year())
-	var joined = year + month + day
-	seed, err := strconv.Atoi(joined)
-	if err != nil {
-		println(err.Error())
-	}
-	rand.Seed(int64(seed))
-
-	// find boundary of largest random number
-	files,_ := ioutil.ReadDir("capys/")
-    var max_rand = len(files)
-
-	// generate random number & set index
-	var index = rand.Intn(max_rand) + 1
+	utils.SetSeed("daily")
+	// set index
+	var index = utils.GetIndex()
 
 	bytes, err := ioutil.ReadFile("capys/capy" + fmt.Sprint(index) + ".jpg")
 


### PR DESCRIPTION
This PR should close issue #4 that @emilio-aburto reported. It's my first time ever writing any go, so please be kind 😂 

The way I solved the issue of wanting a stateless index that still generates randomly picked images per day/hour is by fixing the seed: By concatenating the year/month/day/(hour) into one long number that only changes once per day/hour I fixed the seed for the RNG, so that it generates the same result for that hour/day. I then use that seed to generate a random-but-predictable number between 0 and umber of files in the jpg dir. 

There's probably ways to do this more efficiently in Go, but it should work as is! 